### PR TITLE
Feature/auth-pages

### DIFF
--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -1,0 +1,43 @@
+const BASE_URL = "http://localhost:3000/api/auth"
+
+export const loginRequest = async (data: {
+  username: string
+  password: string
+}) => {
+  const res = await fetch(`${BASE_URL}/login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  })
+
+  const result = await res.json()
+
+  if (!res.ok) {
+    throw new Error(result.message || "Login failed")
+  }
+
+  return result
+}
+
+export const registerRequest = async (data: {
+  username: string
+  password: string
+}) => {
+  const res = await fetch(`${BASE_URL}/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  })
+
+  const result = await res.json()
+
+  if (!res.ok) {
+    throw new Error(result.message || "Registration failed")
+  }
+
+  return result
+}

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react"
+
+interface Props {
+  title: string
+  onSubmit: (data: { username: string; password: string }) => Promise<void>
+}
+
+const AuthForm = ({ title, onSubmit }: Props) => {
+  const [username, setUsername] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState("")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError("")
+
+    // basic validation
+    if (!username || !password) {
+      setError("All fields are required")
+      return
+    }
+
+    if (password.length < 6) {
+      setError("Password must be at least 6 characters")
+      return
+    }
+
+    try {
+      await onSubmit({ username, password })
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} style={{ maxWidth: 400 }}>
+      <h2>{title}</h2>
+
+      {error && <p style={{ color: "red" }}>{error}</p>}
+
+      <input
+        type="text"
+        placeholder="Username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+
+      <button type="submit">{title}</button>
+    </form>
+  )
+}
+
+export default AuthForm

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -14,14 +14,8 @@ const AuthForm = ({ title, onSubmit }: Props) => {
     e.preventDefault()
     setError("")
 
-    // basic validation
     if (!username || !password) {
       setError("All fields are required")
-      return
-    }
-
-    if (password.length < 6) {
-      setError("Password must be at least 6 characters")
       return
     }
 

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,15 @@
+export const useAuth = () => {
+  const saveToken = (token: string) => {
+    localStorage.setItem("token", token)
+  }
+
+  const getToken = () => {
+    return localStorage.getItem("token")
+  }
+
+  const logout = () => {
+    localStorage.removeItem("token")
+  }
+
+  return { saveToken, getToken, logout }
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,19 @@
+import AuthForm from "../components/AuthForm"
+import { useAuth } from "../hooks/useAuth"
+import { useNavigate } from "react-router-dom"
+import { loginRequest } from "../api/authApi"
+
+const LoginPage = () => {
+  const { saveToken } = useAuth()
+  const navigate = useNavigate()
+
+  const handleLogin = async (data: any) => {
+    const response = await loginRequest(data)
+    saveToken(response.token)
+    navigate("/")
+  }
+
+  return <AuthForm title="Login" onSubmit={handleLogin} />
+}
+
+export default LoginPage

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,0 +1,16 @@
+import AuthForm from "../components/AuthForm"
+import { registerRequest } from "../api/authApi"
+import { useNavigate } from "react-router-dom"
+
+const RegisterPage = () => {
+  const navigate = useNavigate()
+
+  const handleRegister = async (data: any) => {
+    await registerRequest(data)
+    navigate("/login")
+  }
+
+  return <AuthForm title="Register" onSubmit={handleRegister} />
+}
+
+export default RegisterPage

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -1,6 +1,9 @@
 import { Routes, Route } from "react-router-dom"
-import HomePage from "../pages/HomePage.tsx"
+import HomePage from "../pages/HomePage"
 import MainLayout from "../layouts/MainLayout"
+
+import LoginPage from "../pages/LoginPage"
+import RegisterPage from "../pages/RegisterPage"
 
 const AppRoutes = () => {
   return (
@@ -8,6 +11,9 @@ const AppRoutes = () => {
       <Route element={<MainLayout />}>
         <Route path="/" element={<HomePage />} />
       </Route>
+
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
     </Routes>
   )
 }

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,8 @@
+export interface AuthResponse {
+  token: string
+}
+
+export interface AuthPayload {
+  username: string
+  password: string
+}


### PR DESCRIPTION
Added login and register pages.
Assumed backend will expect:
POST /api/auth/register 
POST /api/auth/login

Request { "username": "username", "password": "password123" }

Login Response { "token": "jwt-token-here" }